### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ MetaInspector.prototype.getMetaDescription = function()
 }
 
 MetaInspector.prototype.elemContainsTag = function(elem,tagName) {
-	if (elem.name && elem.name === tagName ) {
+	if (elem.tagName && elem.tagName === tagName ) {
 		return true;
 	} else if ( elem.children != undefined ) {
 		for ( let i = 0; i < elem.children.length; i++) {

--- a/index.js
+++ b/index.js
@@ -155,7 +155,7 @@ MetaInspector.prototype.elemContainsTag = function(elem,tagName) {
 	if (elem.tagName && elem.tagName === tagName ) {
 		return true;
 	} else if ( elem.children != undefined ) {
-		for ( let i = 0; i < elem.children.length; i++) {
+		for ( var i = 0; i < elem.children.length; i++) {
 			if ( this.elemContainsTag(elem.children[i], tagName) ) {
 				return true;
 			}

--- a/index.js
+++ b/index.js
@@ -151,12 +151,12 @@ MetaInspector.prototype.getMetaDescription = function()
 	return this;
 }
 
-MetaInspector.prototype.elemContainsTag = function(elem,tag) {
-	if (elem.name && elem.name === tag ) {
+MetaInspector.prototype.elemContainsTag = function(elem,tagName) {
+	if (elem.name && elem.name === tagName ) {
 		return true;
 	} else if ( elem.children != undefined ) {
 		for ( let i = 0; i < elem.children.length; i++) {
-			if ( this.elemContainsTag(elem.children[i], tag) ) {
+			if ( this.elemContainsTag(elem.children[i], tagName) ) {
 				return true;
 			}
 		}

--- a/index.js
+++ b/index.js
@@ -151,6 +151,19 @@ MetaInspector.prototype.getMetaDescription = function()
 	return this;
 }
 
+MetaInspector.prototype.elemContainsTag = function(elem,tag) {
+	if ( elem.type == tag ) {
+		return true;
+	} else if ( elem.children != undefined ) {
+		for ( let i = 0; i < elem.children.length; i++) {
+			if ( this.elemContainsTag(elem.children[i], tag) ) {
+				return true;
+			}
+		}
+	}
+	return false
+}
+
 MetaInspector.prototype.getSecondaryDescription = function()
 {
 	debug("Parsing page secondary description");
@@ -164,12 +177,12 @@ MetaInspector.prototype.getSecondaryDescription = function()
 			if(_this.description){
 				return;
 			}
-
-			var text = _this.parsedDocument(this).text();
-
-			// If we found a paragraph with more than
-			if(text.length >= minimumPLength) {
-				_this.description = text;
+			if ( ! _this.elemContainsTag(elem,"script")) {
+				var text = _this.parsedDocument(this).text();
+				// If we found a paragraph with more than
+				if(text.length >= minimumPLength) {
+					_this.description = text;
+				}
 			}
 		});
 	}

--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ MetaInspector.prototype.getMetaDescription = function()
 }
 
 MetaInspector.prototype.elemContainsTag = function(elem,tag) {
-	if ( elem.type == tag ) {
+	if (elem.name && elem.name === tag ) {
 		return true;
 	} else if ( elem.children != undefined ) {
 		for ( let i = 0; i < elem.children.length; i++) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://github.com/gabceb/node-metainspector",
   "repository": "git://github.com/gabceb/node-metainspector.git",
   "publishConfig": {
-        "registry": "http://nexus.fsc.follett.com/nexus/repository/npm-releases"
+        "registry": "http://nexus.fsc.follett.com/nexus/repository/npm-all"
   },
   "author": "Gabriel Cebrian <gabceb@gmail.com> (http://about.me/gabceb)",
   "main": "./index.js",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "1.3.2",
   "homepage": "http://github.com/gabceb/node-metainspector",
   "repository": "git://github.com/gabceb/node-metainspector.git",
+  "publishConfig": {
+        "registry": "http://nexus.fsc.follett.com/nexus/repository/npm-releases"
+  },
   "author": "Gabriel Cebrian <gabceb@gmail.com> (http://about.me/gabceb)",
   "main": "./index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fss-node-metainspector",
   "description": "Npm package for web scraping purposes. You give it an URL, and it lets you easily get its title, links, images, description, keywords, meta tags",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "homepage": "http://github.com/gabceb/node-metainspector",
   "repository": "git://github.com/gabceb/node-metainspector.git",
   "author": "Gabriel Cebrian <gabceb@gmail.com> (http://about.me/gabceb)",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
   "version": "1.3.2",
   "homepage": "http://github.com/gabceb/node-metainspector",
   "repository": "git://github.com/gabceb/node-metainspector.git",
-  "publishConfig": {
-        "registry": "http://nexus.fsc.follett.com/nexus/repository/npm-releases"
-  },
   "author": "Gabriel Cebrian <gabceb@gmail.com> (http://about.me/gabceb)",
   "main": "./index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://github.com/gabceb/node-metainspector",
   "repository": "git://github.com/gabceb/node-metainspector.git",
   "publishConfig": {
-        "registry": "http://nexus.fsc.follett.com/nexus/repository/npm-all"
+        "registry": "http://nexus.fsc.follett.com/nexus/repository/npm-releases"
   },
   "author": "Gabriel Cebrian <gabceb@gmail.com> (http://about.me/gabceb)",
   "main": "./index.js",

--- a/test/fixtures/fixtures.js
+++ b/test/fixtures/fixtures.js
@@ -6,5 +6,6 @@ fakeweb.registerUri({uri: 'http://www.google.com:80/', file: path.join(__dirname
 fakeweb.registerUri({uri: 'http://www.simple.com:80/', file: path.join(__dirname, 'simple.com.html')});
 fakeweb.registerUri({uri: 'http://www.fastandfurious7-film.com:80/', file: path.join(__dirname, 'fastandfurious7-film.com.html')});
 fakeweb.registerUri({uri: 'http://www.techsuplex.com:80/', file: path.join(__dirname, 'techsuplex.com.html')});
+fakeweb.registerUri({uri: 'http://scriptinptag.html:80/', file: path.join(__dirname, 'scriptinptag.html')});
 
 fakeweb.ignoreUri({uri: 'http://www.google-404.com:80/'});

--- a/test/fixtures/scriptinptag.html
+++ b/test/fixtures/scriptinptag.html
@@ -1,0 +1,39 @@
+<HTML>
+<head>
+<title>This is my title!</title>
+</head>
+<body BGCOLOR="FFFFFF">
+<center><img src="clouds.jpg" ALIGN="BOTTOM"> </center>
+<a href="http://somegreatsite.com">Link Name</a>
+is a link to another nifty site
+<h1>This is a Header</h1>
+<h2>This is a Medium Header</h2>
+Send me mail at <a href="mailto:support@yourcompany.com">
+support@yourcompany.com</a>.
+<p class="break" style="position:absolute;margin-top:-10px;margin-right:5px;">
+<!-- CONDITIONAL LOG-IN STATEMENT  /WELCOME STATEMENT -->
+<div id="convio-content-424030479" style="display: inline;">
+<!-- Standard dependencies for embedded COM content -->
+<script type="text/javascript">
+var Y;
+if (!Y) {
+  Y = YUI({
+    base: 'http://support.nationalww2museum.org/yui3/',
+    debug: false,
+    modules: getModules('http://support.nationalww2museum.org/','convio',false)
+  });
+}
+</script>
+
+<p style="float:right;font-size:12px; font-family:arial,helvetica,sans-serif;color:#1d1d1d;">
+    <a href="http://support.nationalww2museum.org/site/UserLogin">
+        <span><strong>Log In</strong></span></a> |
+    <a href="http://support.nationalww2museum.org/site/ConsProfileUser">Register</a>
+</p>
+<br style="clear:both;">
+</div>
+<!-- END -->
+</p>
+<p>World War II, which began in 1939 and ended in 1945, was the deadliest and most destructive war in history. Before the war, Germany, America, and the rest of the world were going through the Great Depression. The economy was very bad, unemployment was at an all-time high, and massive inflation caused money to lose its value. More than fifty nations in the world were fighting, with more than 100 million soldiers deployed. Countries like America and Britain were part of the Allied powers. Japan and Germany were part of the Axis powers.</p>
+</body>
+</HTML>

--- a/test/test.js
+++ b/test/test.js
@@ -5,16 +5,16 @@ var MetaInspector = require('../index'),
 
 require('./fixtures/fixtures');
 
-describe('metainspector', function () {
+describe('metainspector', function(){
 
-	describe('multiple clients', function () {
+	describe('multiple clients', function(){
 		var firstClient = new MetaInspector('http://www.google.com');
 		var secondClient = new MetaInspector('http://www.google.com');
 
 		it('should not keep the same eventEmitter reference among clients', function (done) {
 			var calledOnce = false;
 
-			firstClient.on('fetch', function () {
+			firstClient.on('fetch', function(){
 				if (!calledOnce) {
 					calledOnce = true;
 				} else {
@@ -22,7 +22,7 @@ describe('metainspector', function () {
 				}
 			});
 
-			secondClient.on('fetch', function () {
+			secondClient.on('fetch', function(){
 				should.exists(secondClient.parsedDocument);
 
 				if (calledOnce) done();
@@ -33,7 +33,7 @@ describe('metainspector', function () {
 		});
 	});
 
-	describe('client', function () {
+	describe('client', function(){
 		var client = null;
 
 		it('should have a url property', function (done) {
@@ -102,7 +102,7 @@ describe('metainspector', function () {
 		it('should have a parsedDocument', function (done) {
 			client = new MetaInspector("http://www.google.com");
 
-			client.once("fetch", function () {
+			client.once("fetch", function(){
 				should.exists(client.parsedDocument);
 				done();
 			});
@@ -113,7 +113,7 @@ describe('metainspector', function () {
 		it('should have a title', function (done) {
 			client = new MetaInspector("http://www.google.com", {});
 
-			client.once("fetch", function () {
+			client.once("fetch", function(){
 				client.title.should.equal("Google");
 				done();
 			});
@@ -124,7 +124,7 @@ describe('metainspector', function () {
 		it('should have keywords', function (done) {
 			client = new MetaInspector("http://www.simple.com", {});
 
-			client.once("fetch", function () {
+			client.once("fetch", function(){
 				client.keywords.should.be.instanceof(Array).and.be.eql(['HTML', 'CSS', 'XML', 'JavaScript']).and.have.lengthOf(4);
 				done();
 			});
@@ -135,7 +135,7 @@ describe('metainspector', function () {
 		it('keywords should be undefined if there is no keywords', function (done) {
 			client = new MetaInspector("http://www.google.com", {});
 
-			client.once("fetch", function () {
+			client.once("fetch", function(){
 				client.keywords.should.be.instanceof(Array).and.be.eql([]);
 				done();
 			});
@@ -146,7 +146,7 @@ describe('metainspector', function () {
 		it('author should be undefined if there is no author', function (done) {
 			client = new MetaInspector("http://www.google.com", {});
 
-			client.once("fetch", function () {
+			client.once("fetch", function(){
 				should.not.exist(client.author);
 				done();
 			});
@@ -157,7 +157,7 @@ describe('metainspector', function () {
 		it('charset should be undefined if there is no charset', function (done) {
 			client = new MetaInspector("http://www.google.com", {});
 
-			client.once("fetch", function () {
+			client.once("fetch", function(){
 				should.not.exist(client.charset);
 				done();
 			});
@@ -168,7 +168,7 @@ describe('metainspector', function () {
 		it('should have author', function (done) {
 			client = new MetaInspector("http://www.simple.com", {});
 
-			client.once("fetch", function () {
+			client.once("fetch", function(){
 				client.author.should.be.equal('Author Name');
 				done();
 			});
@@ -179,7 +179,7 @@ describe('metainspector', function () {
 		it('should have charset', function (done) {
 			client = new MetaInspector("http://www.simple.com", {});
 
-			client.once("fetch", function () {
+			client.once("fetch", function(){
 				client.charset.should.be.equal('UTF-8');
 				done();
 			});
@@ -190,7 +190,7 @@ describe('metainspector', function () {
 		it('should have links returned as an array', function (done) {
 			client = new MetaInspector("http://www.google.com", {});
 
-			client.once("fetch", function () {
+			client.once("fetch", function(){
 				client.links.length.should.equal(51);
 				done();
 			});
@@ -201,7 +201,7 @@ describe('metainspector', function () {
 		it('should have a description', function (done) {
 			client = new MetaInspector("http://www.google.com", {});
 
-			client.once("fetch", function () {
+			client.once("fetch", function(){
 				client.description.should.equal("Search the world's information, including webpages, images, videos and more. Google has many special features to help you find exactly what you're looking for.");
 				done();
 			});
@@ -212,7 +212,7 @@ describe('metainspector', function () {
 		it('should have a og:image with relative path and return as absolute', function (done) {
 			client = new MetaInspector("http://www.fastandfurious7-film.com");
 
-			client.once("fetch", function () {
+			client.once("fetch", function(){
 				client.image.should.equal("http://www.fastandfurious7-film.com/images/fb.jpg");
 				done();
 			});
@@ -223,7 +223,7 @@ describe('metainspector', function () {
 		it('should have a og:description', function (done) {
 			client = new MetaInspector("http://www.fastandfurious7-film.com");
 
-			client.once("fetch", function () {
+			client.once("fetch", function(){
 				client.ogDescription.should.equal("Continuing the global exploits in the unstoppable franchise built on speed, Vin Diesel, Paul Walker and Dwayne Johnson lead the returning cast of Fast & Furious 7.");
 				done();
 			});
@@ -234,7 +234,7 @@ describe('metainspector', function () {
 		it('should return undefined if the meta description is not defined when metaDescription used', function (done) {
 			client = new MetaInspector("http://www.simple.com", {});
 
-			client.once("fetch", function () {
+			client.once("fetch", function(){
 				should.not.exist(client.metaDescription);
 				done();
 			});
@@ -245,7 +245,7 @@ describe('metainspector', function () {
 		it('should find a secondary description if there is no description meta element', function (done) {
 			client = new MetaInspector("http://www.simple.com", {});
 
-			client.once("fetch", function () {
+			client.once("fetch", function(){
 				client.description.should.equal("This is a new paragraph! This paragraph should be very long so we can grab it as the secondary description. What do you think of that?");
 				done();
 			});
@@ -256,7 +256,7 @@ describe('metainspector', function () {
 		it('should find a the image based on the og:image tag if defined', function (done) {
 			client = new MetaInspector("http://www.simple.com", {});
 
-			client.once("fetch", function () {
+			client.once("fetch", function(){
 				client.image.should.equal("http://placehold.it/350x150");
 				done();
 			});
@@ -267,7 +267,7 @@ describe('metainspector', function () {
 		it.skip('should return an array of absolute image paths for all images on the page', function (done) {
 			client = new MetaInspector("http://www.simple.com", {});
 
-			client.once("fetch", function () {
+			client.once("fetch", function(){
 				client.images.should.be.instanceof(Array).and.be.eql(
 					['http://www.simple.com/clouds.jpg',
 						'http://www.simple.com/image/relative.gif',
@@ -284,7 +284,7 @@ describe('metainspector', function () {
 		it('should return an array of rss or atom feeds if defined', function (done) {
 			client = new MetaInspector("http://www.simple.com", {});
 
-			client.once("fetch", function () {
+			client.once("fetch", function(){
 				client.feeds.length.should.equal(2);
 				done();
 			});
@@ -295,7 +295,7 @@ describe('metainspector', function () {
 		it('should return the open graph title if defined', function (done) {
 			client = new MetaInspector("http://www.simple.com", {});
 
-			client.once("fetch", function () {
+			client.once("fetch", function(){
 				client.ogTitle.should.equal("I am an Open Graph title");
 				done();
 			});
@@ -317,7 +317,7 @@ describe('metainspector', function () {
 		it("should return the open graph type, if defined", function (done) {
 			client = new MetaInspector("http://www.techsuplex.com", {});
 
-			client.once("fetch", function () {
+			client.once("fetch", function(){
 				client.ogType.should.exist;
 				client.ogType.should.equal("article");
 				done();
@@ -329,7 +329,7 @@ describe('metainspector', function () {
 		it('should return the last updated time, if defined', function (done) {
 			client = new MetaInspector("http://www.techsuplex.com", {});
 
-			client.once("fetch", function () {
+			client.once("fetch", function(){
 				client.ogUpdatedTime.should.exist;
 				client.ogUpdatedTime.should.equal("2013-10-31T09:29:46+00:00");
 				done();
@@ -341,7 +341,7 @@ describe('metainspector', function () {
 		it('should return the open graph locale, if defined', function (done) {
 			client = new MetaInspector("http://www.techsuplex.com", {});
 
-			client.once("fetch", function () {
+			client.once("fetch", function(){
 				client.ogLocale.should.exist;
 				client.ogLocale.should.equal("en_US");
 				done();
@@ -351,7 +351,7 @@ describe('metainspector', function () {
 		});
 		it("secondaryDescription should ignore any p tag with embedded script tag(s)", function (done) {
 			client = new MetaInspector("http://scriptinptag.html", {});
-			client.once("fetch", function () {
+			client.once("fetch", function(){
 				client.description.should.equal("World War II, which began in 1939 and ended in 1945, was the deadliest and most destructive war in history. Before the war, Germany, America, and the rest of the world were going through the Great Depression. The economy was very bad, unemployment was at an all-time high, and massive inflation caused money to lose its value. More than fifty nations in the world were fighting, with more than 100 million soldiers deployed. Countries like America and Britain were part of the Allied powers. Japan and Germany were part of the Axis powers.");
 				done();
 			});
@@ -359,7 +359,7 @@ describe('metainspector', function () {
 		});
 		it("elemContainsTag should return true for any tag that holds a script tag and false otherwise", function (done) {
 			client = new MetaInspector("http://scriptinptag.html", {});
-			client.once("fetch", function () {
+			client.once("fetch", function(){
 				client.parsedDocument("p").each(function (i, elem) {
 					switch (i) {
 						case 0:

--- a/test/test.js
+++ b/test/test.js
@@ -5,16 +5,16 @@ var MetaInspector = require('../index'),
 
 require('./fixtures/fixtures');
 
-describe('metainspector', function(){
+describe('metainspector', function () {
 
-	describe('multiple clients', function(){
+	describe('multiple clients', function () {
 		var firstClient = new MetaInspector('http://www.google.com');
 		var secondClient = new MetaInspector('http://www.google.com');
 
-		it('should not keep the same eventEmitter reference among clients', function(done){
+		it('should not keep the same eventEmitter reference among clients', function (done) {
 			var calledOnce = false;
 
-			firstClient.on('fetch', function(){
+			firstClient.on('fetch', function () {
 				if (!calledOnce) {
 					calledOnce = true;
 				} else {
@@ -22,7 +22,7 @@ describe('metainspector', function(){
 				}
 			});
 
-			secondClient.on('fetch', function(){
+			secondClient.on('fetch', function () {
 				should.exists(secondClient.parsedDocument);
 
 				if (calledOnce) done();
@@ -33,76 +33,76 @@ describe('metainspector', function(){
 		});
 	});
 
-	describe('client', function(){
+	describe('client', function () {
 		var client = null;
 
-		it('should have a url property', function(done){
+		it('should have a url property', function (done) {
 			client = new MetaInspector("http://www.google.com");
 
 			client.url.should.equal("http://www.google.com/");
 			done();
 		});
 
-		it('should add http as the default scheme if no scheme is passed', function(done){
+		it('should add http as the default scheme if no scheme is passed', function (done) {
 			client = new MetaInspector("www.google.com");
 
 			client.url.should.equal("http://www.google.com/");
 			done();
 		});
 
-		it('should have a scheme property', function(done){
+		it('should have a scheme property', function (done) {
 			client = new MetaInspector("http://www.google.com");
 
 			client.scheme.should.equal("http");
 			done();
 		});
 
-		it('should have a host property', function(done){
+		it('should have a host property', function (done) {
 			client = new MetaInspector("http://www.google.com");
 
 			client.host.should.equal("www.google.com");
 			done();
 		});
 
-		it('should not include port number in host', function(done){
+		it('should not include port number in host', function (done) {
 			client = new MetaInspector("http://www.google.com:8000");
 
 			client.host.should.equal("www.google.com");
 			done();
 		});
 
-		it('should have a port property', function(done){
+		it('should have a port property', function (done) {
 			client = new MetaInspector("http://www.google.com:8000");
 
 			client.port.should.equal(8000);
 			done();
 		});
 
-		it('port should be undefined if not specified in original url', function(done){
+		it('port should be undefined if not specified in original url', function (done) {
 			client = new MetaInspector("http://www.google.com");
 
 			should.equal(client.port, undefined);
 			done();
 		});
 
-		it('should have a rootUrl property', function(done){
+		it('should have a rootUrl property', function (done) {
 			client = new MetaInspector("http://www.google.com");
 
 			client.rootUrl.should.equal("http://www.google.com");
 			done();
 		});
 
-		it('should include port number in rootUrl if specified in original url', function(done){
+		it('should include port number in rootUrl if specified in original url', function (done) {
 			client = new MetaInspector("http://www.google.com:8000");
 
 			client.rootUrl.should.equal("http://www.google.com:8000");
 			done();
 		});
 
-		it('should have a parsedDocument', function(done){
+		it('should have a parsedDocument', function (done) {
 			client = new MetaInspector("http://www.google.com");
 
-			client.once("fetch", function(){
+			client.once("fetch", function () {
 				should.exists(client.parsedDocument);
 				done();
 			});
@@ -110,10 +110,10 @@ describe('metainspector', function(){
 			client.fetch();
 		});
 
-		it('should have a title', function(done){
+		it('should have a title', function (done) {
 			client = new MetaInspector("http://www.google.com", {});
 
-			client.once("fetch", function(){
+			client.once("fetch", function () {
 				client.title.should.equal("Google");
 				done();
 			});
@@ -121,21 +121,21 @@ describe('metainspector', function(){
 			client.fetch();
 		});
 
-		it('should have keywords', function(done){
+		it('should have keywords', function (done) {
 			client = new MetaInspector("http://www.simple.com", {});
 
-			client.once("fetch", function(){
-				client.keywords.should.be.instanceof(Array).and.be.eql([ 'HTML', 'CSS', 'XML', 'JavaScript' ]).and.have.lengthOf(4);
+			client.once("fetch", function () {
+				client.keywords.should.be.instanceof(Array).and.be.eql(['HTML', 'CSS', 'XML', 'JavaScript']).and.have.lengthOf(4);
 				done();
 			});
 
 			client.fetch();
 		});
 
-		it('keywords should be undefined if there is no keywords', function(done){
+		it('keywords should be undefined if there is no keywords', function (done) {
 			client = new MetaInspector("http://www.google.com", {});
 
-			client.once("fetch", function(){
+			client.once("fetch", function () {
 				client.keywords.should.be.instanceof(Array).and.be.eql([]);
 				done();
 			});
@@ -143,10 +143,10 @@ describe('metainspector', function(){
 			client.fetch();
 		});
 
-		it('author should be undefined if there is no author', function(done){
+		it('author should be undefined if there is no author', function (done) {
 			client = new MetaInspector("http://www.google.com", {});
 
-			client.once("fetch", function(){
+			client.once("fetch", function () {
 				should.not.exist(client.author);
 				done();
 			});
@@ -154,10 +154,10 @@ describe('metainspector', function(){
 			client.fetch();
 		});
 
-		it('charset should be undefined if there is no charset', function(done){
+		it('charset should be undefined if there is no charset', function (done) {
 			client = new MetaInspector("http://www.google.com", {});
 
-			client.once("fetch", function(){
+			client.once("fetch", function () {
 				should.not.exist(client.charset);
 				done();
 			});
@@ -165,10 +165,10 @@ describe('metainspector', function(){
 			client.fetch();
 		});
 
-		it('should have author', function(done){
+		it('should have author', function (done) {
 			client = new MetaInspector("http://www.simple.com", {});
 
-			client.once("fetch", function(){
+			client.once("fetch", function () {
 				client.author.should.be.equal('Author Name');
 				done();
 			});
@@ -176,10 +176,10 @@ describe('metainspector', function(){
 			client.fetch();
 		});
 
-		it('should have charset', function(done){
+		it('should have charset', function (done) {
 			client = new MetaInspector("http://www.simple.com", {});
 
-			client.once("fetch", function(){
+			client.once("fetch", function () {
 				client.charset.should.be.equal('UTF-8');
 				done();
 			});
@@ -187,10 +187,10 @@ describe('metainspector', function(){
 			client.fetch();
 		});
 
-		it('should have links returned as an array', function(done){
+		it('should have links returned as an array', function (done) {
 			client = new MetaInspector("http://www.google.com", {});
 
-			client.once("fetch", function(){
+			client.once("fetch", function () {
 				client.links.length.should.equal(51);
 				done();
 			});
@@ -198,10 +198,10 @@ describe('metainspector', function(){
 			client.fetch();
 		});
 
-		it('should have a description', function(done){
+		it('should have a description', function (done) {
 			client = new MetaInspector("http://www.google.com", {});
 
-			client.once("fetch", function(){
+			client.once("fetch", function () {
 				client.description.should.equal("Search the world's information, including webpages, images, videos and more. Google has many special features to help you find exactly what you're looking for.");
 				done();
 			});
@@ -209,10 +209,10 @@ describe('metainspector', function(){
 			client.fetch();
 		});
 
-		it('should have a og:image with relative path and return as absolute', function(done){
+		it('should have a og:image with relative path and return as absolute', function (done) {
 			client = new MetaInspector("http://www.fastandfurious7-film.com");
 
-			client.once("fetch", function(){
+			client.once("fetch", function () {
 				client.image.should.equal("http://www.fastandfurious7-film.com/images/fb.jpg");
 				done();
 			});
@@ -220,10 +220,10 @@ describe('metainspector', function(){
 			client.fetch();
 		});
 
-		it('should have a og:description', function(done){
+		it('should have a og:description', function (done) {
 			client = new MetaInspector("http://www.fastandfurious7-film.com");
 
-			client.once("fetch", function(){
+			client.once("fetch", function () {
 				client.ogDescription.should.equal("Continuing the global exploits in the unstoppable franchise built on speed, Vin Diesel, Paul Walker and Dwayne Johnson lead the returning cast of Fast & Furious 7.");
 				done();
 			});
@@ -231,10 +231,10 @@ describe('metainspector', function(){
 			client.fetch();
 		});
 
-		it('should return undefined if the meta description is not defined when metaDescription used', function(done){
+		it('should return undefined if the meta description is not defined when metaDescription used', function (done) {
 			client = new MetaInspector("http://www.simple.com", {});
 
-			client.once("fetch", function(){
+			client.once("fetch", function () {
 				should.not.exist(client.metaDescription);
 				done();
 			});
@@ -242,10 +242,10 @@ describe('metainspector', function(){
 			client.fetch();
 		});
 
-		it('should find a secondary description if there is no description meta element', function(done){
+		it('should find a secondary description if there is no description meta element', function (done) {
 			client = new MetaInspector("http://www.simple.com", {});
 
-			client.once("fetch", function(){
+			client.once("fetch", function () {
 				client.description.should.equal("This is a new paragraph! This paragraph should be very long so we can grab it as the secondary description. What do you think of that?");
 				done();
 			});
@@ -253,10 +253,10 @@ describe('metainspector', function(){
 			client.fetch();
 		});
 
-		it('should find a the image based on the og:image tag if defined', function(done){
+		it('should find a the image based on the og:image tag if defined', function (done) {
 			client = new MetaInspector("http://www.simple.com", {});
 
-			client.once("fetch", function(){
+			client.once("fetch", function () {
 				client.image.should.equal("http://placehold.it/350x150");
 				done();
 			});
@@ -264,27 +264,27 @@ describe('metainspector', function(){
 			client.fetch();
 		});
 
-		it.skip('should return an array of absolute image paths for all images on the page', function(done){
+		it.skip('should return an array of absolute image paths for all images on the page', function (done) {
 			client = new MetaInspector("http://www.simple.com", {});
 
-			client.once("fetch", function(){
+			client.once("fetch", function () {
 				client.images.should.be.instanceof(Array).and.be.eql(
-					[ 'http://www.simple.com/clouds.jpg',
+					['http://www.simple.com/clouds.jpg',
 						'http://www.simple.com/image/relative.gif',
 						'http://www.simple.com/image/relative2.gif',
 						'http://placehold.it/350x150',
 						'https://placehold.it/350x65',
-						'//placehold.it/350x65' ]);
+						'//placehold.it/350x65']);
 				done();
 			});
 
 			client.fetch();
 		});
 
-		it('should return an array of rss or atom feeds if defined', function(done){
+		it('should return an array of rss or atom feeds if defined', function (done) {
 			client = new MetaInspector("http://www.simple.com", {});
 
-			client.once("fetch", function(){
+			client.once("fetch", function () {
 				client.feeds.length.should.equal(2);
 				done();
 			});
@@ -292,10 +292,10 @@ describe('metainspector', function(){
 			client.fetch();
 		});
 
-		it('should return the open graph title if defined', function(done){
+		it('should return the open graph title if defined', function (done) {
 			client = new MetaInspector("http://www.simple.com", {});
 
-			client.once("fetch", function(){
+			client.once("fetch", function () {
 				client.ogTitle.should.equal("I am an Open Graph title");
 				done();
 			});
@@ -303,10 +303,10 @@ describe('metainspector', function(){
 			client.fetch();
 		});
 
-		it('should emit errors', function(done){
+		it('should emit errors', function (done) {
 			client = new MetaInspector("http://www.google-404.com/", {});
 
-			client.once("error", function(error){
+			client.once("error", function (error) {
 				should.exists(error);
 				done();
 			});
@@ -314,10 +314,10 @@ describe('metainspector', function(){
 			client.fetch();
 		});
 
-		it("should return the open graph type, if defined", function(done){
+		it("should return the open graph type, if defined", function (done) {
 			client = new MetaInspector("http://www.techsuplex.com", {});
 
-			client.once("fetch", function() {
+			client.once("fetch", function () {
 				client.ogType.should.exist;
 				client.ogType.should.equal("article");
 				done();
@@ -326,10 +326,10 @@ describe('metainspector', function(){
 			client.fetch();
 		});
 
-		it('should return the last updated time, if defined', function(done){
+		it('should return the last updated time, if defined', function (done) {
 			client = new MetaInspector("http://www.techsuplex.com", {});
 
-			client.once("fetch", function() {
+			client.once("fetch", function () {
 				client.ogUpdatedTime.should.exist;
 				client.ogUpdatedTime.should.equal("2013-10-31T09:29:46+00:00");
 				done();
@@ -338,15 +338,50 @@ describe('metainspector', function(){
 			client.fetch();
 		});
 
-		it('should return the open graph locale, if defined', function(done){
+		it('should return the open graph locale, if defined', function (done) {
 			client = new MetaInspector("http://www.techsuplex.com", {});
 
-			client.once("fetch", function() {
+			client.once("fetch", function () {
 				client.ogLocale.should.exist;
 				client.ogLocale.should.equal("en_US");
 				done();
 			});
 
+			client.fetch();
+		});
+		it("secondaryDescription should ignore any p tag with embedded script tag(s)", function (done) {
+			client = new MetaInspector("http://scriptinptag.html", {});
+			client.once("fetch", function () {
+				client.description.should.equal("World War II, which began in 1939 and ended in 1945, was the deadliest and most destructive war in history. Before the war, Germany, America, and the rest of the world were going through the Great Depression. The economy was very bad, unemployment was at an all-time high, and massive inflation caused money to lose its value. More than fifty nations in the world were fighting, with more than 100 million soldiers deployed. Countries like America and Britain were part of the Allied powers. Japan and Germany were part of the Axis powers.");
+				done();
+			});
+			client.fetch();
+		});
+		it("elemContainsTag should return true for any tag that holds a script tag and false otherwise", function (done) {
+			client = new MetaInspector("http://scriptinptag.html", {});
+			client.once("fetch", function () {
+				client.parsedDocument("p").each(function (i, elem) {
+					switch (i) {
+						case 0:
+							client.elemContainsTag(elem, "script").should.equal(true);
+							break;
+						default:
+							client.elemContainsTag(elem, "script").should.equal(false);
+							break;
+					}
+				});
+				client.parsedDocument("a").each(function (i, elem) {
+					switch (i) {
+						case 2: // 3rd a tag in html: the Login link
+							client.elemContainsTag(elem, "span").should.equal(true);
+							break;
+						default:
+							client.elemContainsTag(elem, "span").should.equal(false);
+							break;
+					}
+				});
+				done();
+			});
 			client.fetch();
 		});
 	});


### PR DESCRIPTION
p tags are used to generate the description when other methods fail.  However, there are cases where the p tag may have internal  script tags and the javascript is interpreted as text  and so is used for  the  description; this is an obvious error. This fix removes any p tag  with internal script tags from consideration when generating a description. Follett internal reference D-21669.